### PR TITLE
Fix §11.2 black sun coordinate to sit on the +Z_cs boundary

### DIFF
--- a/CYBERSPACE_V2.md
+++ b/CYBERSPACE_V2.md
@@ -1279,9 +1279,11 @@ The "black sun" is a reference to the hacker haven in Neal Stephenson's *Snow Cr
 
 If a visualizer renders the black sun, it MUST place it on the `+Z_cs` boundary of the Cyberspace cube.
 
-At u85 position `2^84` (the half-axis extent):
-- `black_sun_u85 = (x=0, y=0, z=2^84)` in u85 coordinates
-- In physical units: `black_sun = (x_km=0, y_km=0, z_km=+2.25×10^12 km)` (approximately 0.24 light-years from origin)
+The `+Z_cs` boundary is the Z axis maximum, `2^85 - 1` (§2.1). The marker is placed at the center of that face:
+- `black_sun_u85 = (x=2^84, y=2^84, z=2^85 - 1)` in u85 coordinates
+- In physical units: `black_sun = (x_km=0, y_km=0, z_km≈+2.25×10^12 km)`, one half-axis (approximately 0.24 light-years) from the cube center along `+Z_cs`
+
+These two forms describe the same point. The physical frame of §9.7 is centered on the cube, so `km=0` on each axis is u85 `2^84`, whereas u85 values are measured from the cube corner. Converting the km figures above with the §9.7 formula lands on the u85 coordinate above, up to the rounding in the km figure (the exact half-axis is `2251799813685.248` km).
 
 The black sun is a directional guidepost for east (`+Z_cs`). Marker color SHOULD be purple. Marker shape (point/sphere/circle/disk) is implementation-defined.
 

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,12 @@ cyberspace history
 cyberspace chain status
 ```
 
+**Interactive movement visualization:**
+```bash
+cyberspace move viz
+```
+Launch a terminal TUI for planning movements. Navigate with arrow keys or `a`/`d`, switch axes with `x`/`y`/`z`, use `:` to jump to an offset, and press Enter to execute. The visualization shows adjacent coordinates, LCA heights, terrain difficulty (K), and estimated compute time.
+
 Other useful utilities:
 ```bash
 cyberspace sector


### PR DESCRIPTION
Two defects in §11.2. Both trace to one root cause: `2^84` was treated as the u85 axis maximum when it is the half-axis point.

## Defect 1: the stated coordinate is not on the `+Z_cs` boundary

§11.2 says the marker MUST sit on the `+Z_cs` boundary, then gives:

```
black_sun_u85 = (x=0, y=0, z=2^84)
```

Each axis is 85 bits (§2.1: "an unsigned integer from 0 to 2^85 - 1"), so the axis maximum is `2^85 - 1`. That makes `z = 2^84` the middle of the Z axis and `x = y = 0` the axis minimum. The stated point is the center of the `-X,-Y` edge, which touches no `+Z` boundary at all.

**Provenance.** `git show 088a7cc` ("Fix §10.2 black sun position with correct axis extent") introduced this text, and its message reads:

> At u85 position `2^84` (the maximum u85 value, representing the half-axis extent)

`2^84` is not the maximum, it is the half-axis point. The prose was later corrected to "the half-axis extent", which is right, but the coordinate itself was never moved.

**Fix.** `black_sun_u85 = (x=2^84, y=2^84, z=2^85 - 1)`.

`z = 2^85 - 1` is forced by the "boundary" requirement, and matches §9.7's own clamp to `[0, 2^85 - 1]`. `x` and `y` are free, as you note, since the marker is a `+Z` guidepost. I chose the face center for three reasons:

1. It is what the existing physical figure already says. `x_km = 0, y_km = 0` converts through §9.7 to exactly `2^84`.
2. `z` at the axis maximum guarantees `v_z >= 0` for every spawn in the cube, so the marker is never behind the viewer. Over 2000 random pubkeys the max angle from `+Z_cs` is 89.8 degrees, never exceeding 90. The current coordinate puts the marker *behind* 51.1% of spawns.
3. Among face placements it minimizes angular error (2000 spawns): face center 42.1 deg mean, `-X,-Y` corner 57.4 deg, `+X,+Y` corner 57.2 deg.

## Defect 2: stranded physical gloss

`088a7cc` also added a guard note:

> The GPS to dataspace mapping in §4.4 maps GPS coordinates into a GEO-centered region spanning ~48,000 km. The black sun is at the full half-axis extent (~2.25 trillion km), far beyond this region. Do not use the §4.4 `units_per_km` formula for black sun positioning; use the u85 coordinate directly.

That guard is no longer in the spec (`grep` for `units_per_km` now returns only the two §9.7 formula lines). The figure it guarded, `z_km=+2.25x10^12 km`, is still there. So a reader converts it through §9.7's `u = km * 1000 * 2^33 + 2^84` and gets:

| input | output |
|---|---|
| `x_km = 0` | `2^84` = 19342813113834066795298816 |
| `y_km = 0` | `2^84` |
| `z_km = 2.25x10^12` | 38670165945834066795298816, i.e. `0.9996 * 2^85` |

Landing on `(2^84, 2^84, ~2^85)`, a different point from the stated one. Confirmed.

**I restored neither the guard nor removed the figure.** Both were the wrong call once Defect 1 is fixed, because the physical figure was correct all along and the u85 triple was the inconsistent one:

- §9.7 puts `km = 0` at u85 `2^84`, so the km frame is **cube-centered** while u85 is **corner-relative**.
- §9.2 gives the half-axis as ~2.25 trillion km. Center plus one half-axis is exactly the `+Z` boundary.
- So `(0, 0, +2.25x10^12 km)` already denoted the `+Z` face center. Converting it is not a reader error, it is the correct reading.

Restoring the guard would have told readers to ignore a conversion that now produces the right answer, and its premise ("the black sun is at the full half-axis extent", meaning `2^84`) is the bug itself. Removing the figure would have discarded the one part of the block that was right. Instead the diff states that the two forms describe the same point and names the center-versus-corner frame difference that made them look inconsistent. The `2.25` vs exact `2251799813685.248` km gap is rounding, now flagged inline.

## Open question, not addressed in this diff: point vs direction

§11.2 defines a **point**. §11.3 defines "facing the black sun" as looking toward `+Z_cs`. These are only compatible if the marker is at effective infinity, and it is not: it is ~0.24 light-years away (§9.2) while a pubkey-derived spawn sits off-axis by a comparable distance. For a sample spawn the distance to the marker came to 0.52 light-years, same order as the offset itself.

Measured angle between `+Z_cs` and the bearing to the marker, decoding pubkeys to xyz with the §2.3 interleaving (round-trip verified against `xyz_to_coord`):

| marker | 12 pubkeys (mean) | 2000 pubkeys (mean) | max | marker behind viewer |
|---|---|---|---|---|
| stated `(0, 0, 2^84)` | 76.0 deg | 90.9 deg | 175.9 deg | 51.1% |
| km-converted `(2^84, 2^84, ~2^85)` | 35.5 deg | 42.1 deg | 89.9 deg | 0% |
| this PR `(2^84, 2^84, 2^85-1)` | 35.5 deg | 42.1 deg | 89.8 deg | 0% |

So this fix cuts the mean error roughly in half and eliminates the case where the "guidepost for `+Z`" renders behind you, but it does **not** make §11.2 and §11.3 consistent. A 42 degree mean discrepancy remains, up to ~90 degrees worst case.

This is a normative judgement, so I have not touched §11.3 or redefined the marker as a bearing. The options as I see them:

1. **Marker stays a point.** §11.3's "facing the black sun" becomes shorthand for "looking toward `+Z_cs`", and the two coincide only near the `-Z` face. The phrase is then misleading at most coordinates.
2. **Marker becomes a fixed `+Z_cs` bearing**, rendered at effective infinity (skybox-style, direction only, no position). §11.3 then holds exactly from any coordinate, and §11.2's coordinate becomes illustrative rather than normative.

Worth noting for the decision: **ONOSENDAI already renders it as a fixed `+Z` bearing** so that §11.3 holds from any coordinate. If that is the intended semantics, option 2 makes the spec match a shipping client, and §11.2's MUST-place-at-a-point language should be revisited.

## Scope

`CYBERSPACE_V2.md` §11.2 only, 5 insertions and 3 deletions. No golden vectors touched: `visualization_vectors.json` has no black sun entry, and no other file in the repo carries a copy of the coordinate. §11.3 unchanged by design.
