### PR TITLE
Sidestep v2: seed the leaves so crossings are tolls, not roads

### DIFF
--- a/CYBERSPACE_V2.md
+++ b/CYBERSPACE_V2.md
@@ -1617,6 +1617,6 @@ Implementers should treat that repo as the reference for:
 - Canonical GPS→dataspace mapping (`CANONICAL_GPS_TO_DATASPACE_SPEC_VERSION` and golden vectors)
 
 This repository also carries stdlib-only reference scripts that are executable statements of specific sections, each self-checking when run:
-- `sidestep-reference.py` — the v2 sidestep construction (§6.4, §6.5, §6.10, §6.11), with golden vectors and a check that each property those sections claim actually holds
-- `hint-reference.py` — §7.7 and the §10 rule for bags: canonical form, containment, sector tags, seeker work, malformed hints and plane preservation, locking the golden vectors of §7.7
-- `decks/landfall-reference.py` — landfall derivation (DECK-0001 §1.2)
+- `sidestep-reference.py`: the v2 sidestep construction (§6.4, §6.5, §6.10, §6.11), with golden vectors and a check that each property those sections claim actually holds
+- `hint-reference.py`: §7.7 and the §10 rule for bags: canonical form, containment, sector tags, seeker work, malformed hints and plane preservation, locking the golden vectors of §7.7
+- `decks/landfall-reference.py`: landfall derivation (DECK-0001 §1.2)

--- a/CYBERSPACE_V2.md
+++ b/CYBERSPACE_V2.md
@@ -843,6 +843,8 @@ With `SIDESTEP_SAMPLES = 8`, passing half the time requires honestly computing a
 
 In practice, Level 1 is for routine validation. Level 2 is for auditors, competitors, or automated fraud-detection services.
 
+**Small heights (non-normative).** Level 1 costs about `(SIDESTEP_SAMPLES + 1) × (h + 1)` hash operations and Level 2 costs `2^(h+1) - 1`, so the two cross over near h5. Below that, a verifier SHOULD simply perform Level 2, which is both cheaper and complete. Provers still publish the full opening set at every height, so that the `mp` encoding of §8.5 stays fixed-width.
+
 ### 6.12 Entering ≠ claiming (non-normative)
 
 The sidestep Merkle tree is built over SHA-256 hashes of leaf coordinates. The Cantor pairing tree over those same leaves produces a completely different value. Computing the Merkle root reveals **nothing** about the Cantor root.

--- a/CYBERSPACE_V2.md
+++ b/CYBERSPACE_V2.md
@@ -906,6 +906,10 @@ The seeding of §6.4, the axis separation of §6.4, and the sampled openings of 
 
 Implementations of the base protocol prior to this revision computed leaves as `SHA256(b"CYBERSPACE_SIDESTEP_V1" || leaf_bytes)` with no seed and no axis separation, and published a single destination inclusion path. Those proofs are recognisable by their `mp` tag carrying exactly one path per axis rather than `SIDESTEP_SAMPLES + 1`.
 
+**Porting hazard: which leaf the path covers.** v1 implementations diverged on this and the spec was not the tie-breaker it should have been. §6.10 and §8.7.2 have always specified the **destination** leaf, and that is what the two TypeScript ports and every sidestep so far published to a public relay actually use. The Python reference implementation named in §14 instead collected the path for leaf 0, the base of the aligned subtree, so its inclusion verifier rejects conforming events and accepts its own. Because the choice never entered `region_m`, it never affected `proof_hash`, which is why the divergence survived: the events verified at the proof level while their `mp` tags were mutually unreadable.
+
+Implementations porting to v2 MUST use destination-leaf semantics for the first opening. The sampled openings make any remaining divergence self-correcting, since a verifier built on the wrong convention fails the sampled paths as well as the destination path, rather than silently ignoring both.
+
 ---
 
 ## 7. Location-Based Encryption and Discovery

--- a/CYBERSPACE_V2.md
+++ b/CYBERSPACE_V2.md
@@ -74,11 +74,12 @@ For extended design rationale and philosophical discussion, see [`RATIONALE.md`]
   - [6.7 Temporal binding](#67-temporal-binding)
   - [6.8 Sidestep proof hash (normative)](#68-sidestep-proof-hash-normative)
   - [6.9 Multi-axis sidestep](#69-multi-axis-sidestep)
-  - [6.10 Merkle inclusion proof](#610-merkle-inclusion-proof)
+  - [6.10 Openings (normative)](#610-openings-normative)
   - [6.11 Verification levels](#611-verification-levels)
   - [6.12 Entering ≠ claiming (non-normative)](#612-entering--claiming-non-normative)
   - [6.13 Natural continents (non-normative)](#613-natural-continents-non-normative)
   - [6.14 Performance expectations (non-normative)](#614-performance-expectations-non-normative)
+  - [6.15 Version 2 of the sidestep construction (normative)](#615-version-2-of-the-sidestep-construction-normative)
 - [7. Location-Based Encryption and Discovery](#7-location-based-encryption-and-discovery)
   - [7.1 The purpose: chalk on the sidewalk (non-normative)](#71-the-purpose-chalk-on-the-sidewalk-non-normative)
   - [7.2 Key derivation (normative)](#72-key-derivation-normative)
@@ -615,12 +616,18 @@ But walls are only interesting if there's a way to get past them — expensively
 
 A **sidestep** action traverses 1 Gibson in a direction using an alternative POW that makes otherwise impossible LCA barriers feasible to cross. Instead of Cantor pairing, a sidestep produces a tree with a **Merkle hash tree** over SHA-256 hashes of leaf coordinates. The critical insight: SHA-256 operations are **fixed-size** (256 bits in, 256 bits out) regardless of tree height. No storage bottleneck. The cost of a sidestep is purely **time**: how long it takes to hash every leaf coordinate.
 
-At heights above roughly h16 a sidestep is cheaper in wall-clock time than the equivalent hop, and the gap widens with height (see §6.14). The hop remains the primitive that produces a region root; the sidestep is the primitive that crosses a boundary. Only hop actions produce the root; sidesteps forego calculating it, but remain valid for travesal.
+At heights above roughly h16 a sidestep is cheaper in wall-clock time than the equivalent hop, and the gap widens with height (see §6.14). The hop remains the primitive that produces a region root; the sidestep is the primitive that crosses a boundary. An agent hops when it wants the root (a discovery key or a domain) and sidesteps when it wants to move.
+
+The sidestep is a **toll**: its work is seeded by the mover's chain position, so it is paid in full by every traveller and cannot be reduced, sold, or inherited from anyone else's published proof (§6.4, §6.15). The hop is deliberately not a toll, because its work product is a canonical region root that a holder may choose to share (§6.12).
 
 **Core terms:**
 - **Sidestep:** A movement action that crosses an LCA boundary via a Merkle hash tree proof instead of a Cantor pairing tree proof. Crosses exactly 1 Gibson past the boundary, regardless of the amount of work it takes.
-- **Merkle root (sidestep):** The root hash of a binary Merkle tree built over SHA-256 hashes of every leaf coordinate in an aligned subtree. Domain-separated from other protocol hashes.
-- **SIDESTEP_DOMAIN:** `b"CYBERSPACE_SIDESTEP_V1"`, the domain separation prefix used for all sidestep leaf hashes.
+- **Merkle root (sidestep):** The root hash of a binary Merkle tree built over SHA-256 hashes of every leaf coordinate in an aligned subtree, **seeded by the mover's chain position**. Domain-separated from other protocol hashes.
+- **Toll:** The property that a sidestep's spatial work is non-transferable. Every traveller crossing a given boundary pays the full price; no published proof reduces the cost for any other traveller.
+- **Openings:** The inclusion paths published with a sidestep: the destination leaf's path plus `SIDESTEP_SAMPLES` paths at pseudorandomly sampled positions (§6.10).
+- **SIDESTEP_DOMAIN:** `b"CYBERSPACE_SIDESTEP_V2"`, the domain separation prefix used for all sidestep leaf hashes.
+- **SIDESTEP_SAMPLE_DOMAIN:** `b"CYBERSPACE_SIDESTEP_SAMPLE_V1"`, the domain separation prefix used to derive sampled opening indices.
+- **SIDESTEP_SAMPLES:** `8`, the number of sampled openings published per non-trivial axis.
 
 ### 6.3 Sidestep geometry (normative)
 
@@ -646,6 +653,14 @@ A verifier at Level 1 (§6.11) checks this geometry directly from the event's co
 
 ### 6.4 Per-axis Merkle root (normative)
 
+Sidestep leaves are **seeded**. Let `previous_event_id` be the 32 raw bytes of the id referenced by this event's `e` tag with marker `previous`, and let `axis_byte` be a single byte identifying the axis: `0x00` for X, `0x01` for Y, `0x02` for Z. Define the per-axis seed prefix:
+
+```
+seed_prefix = SIDESTEP_DOMAIN || previous_event_id || axis_byte || SEED_PAD
+```
+
+`SIDESTEP_DOMAIN` is 22 bytes and `SEED_PAD` is 9 zero bytes, so `seed_prefix` is **exactly 64 bytes**: one full SHA-256 block. This is deliberate (§6.5).
+
 For each axis where movement occurs (`v1 ≠ v2`):
 
 1. Compute `h = find_lca_height(v1, v2)`.
@@ -653,7 +668,7 @@ For each axis where movement occurs (`v1 ≠ v2`):
 3. The aligned subtree contains `2^h` leaves: `[base, base+1, ..., base + 2^h - 1]`.
 4. For each leaf value `L_i` (where `i` ranges from `0` to `2^h - 1`):
    - Encode as big-endian minimal bytes: `leaf_bytes = int_to_bytes_be_min(base + i)`
-   - Compute leaf hash: `H_i = SHA256(SIDESTEP_DOMAIN || leaf_bytes)`
+   - Compute leaf hash: `H_i = SHA256(seed_prefix || leaf_bytes)`
 5. Build the Merkle tree bottom-up:
    - For each pair `(H_{2j}, H_{2j+1})`: `parent = SHA256(H_{2j} || H_{2j+1})`
    - Continue until a single root `M_axis` remains.
@@ -661,12 +676,17 @@ For each axis where movement occurs (`v1 ≠ v2`):
 
 **Domain separation constant (normative):**
 ```
-SIDESTEP_DOMAIN = b"CYBERSPACE_SIDESTEP_V1"
+SIDESTEP_DOMAIN = b"CYBERSPACE_SIDESTEP_V2"   # 22 bytes
+SEED_PAD        = b"\x00" * 9                 # brings seed_prefix to exactly 64 bytes
 ```
 
 If any aspect of sidestep leaf hash computation changes in a future version (preimage format, domain string, encoding), the domain string MUST be bumped to a new value to avoid cross-version collisions.
 
-**Trivial axes (`h = 0`):** When `v1 == v2` on an axis, the Merkle root is the single leaf hash: `M_axis = SHA256(SIDESTEP_DOMAIN || int_to_bytes_be_min(v1))`. No tree construction is needed.
+**Trivial axes (`h = 0`):** When `v1 == v2` on an axis, the Merkle root is the single leaf hash: `M_axis = SHA256(seed_prefix || int_to_bytes_be_min(v1))`. No tree construction is needed.
+
+**Why the seed (normative rationale):** Without it, the leaf preimage contains no identity and no chain context, so the root for a given aligned subtree is the same 32 bytes for every traveller in the history of the protocol. Because the destination is deterministic (§6.3) and both the roots and the openings are published in the clear (§8.5), the first identity to cross any boundary would publish everything a later identity needs: a follower could copy `mr` and `mp` from a relay, compute only the temporal axis (at most 2^16 Cantor pairs, about 100 ms), and produce a proof that passes both verification levels, because the copied root *is* the correct root. Boundary crossings would be priced for the pioneer and free for everyone after. The seed makes each traveller's tree unique to its chain position, so the price in §6.14 is what every traveller pays, every time.
+
+**Why the axis byte (normative rationale):** Earth is centred at exactly `2^84` on every axis (§9.7) and its surface radius is about `2^55.6` Gibsons. Because `2^84` is a multiple of `2^h` for every `h ≤ 84`, the centre is always a cell boundary, so above about h56 the aligned base on each axis takes one of only two values, and any two axes falling on the same side of the centre plane share it exactly. Without axis separation such a crossing would compute one tree and claim it as two or three, and §6.9's "the total work is the sum of per-axis work" would be false by that factor at exactly the heights where the work is largest.
 
 ### 6.5 Streaming computation (normative)
 
@@ -678,15 +698,15 @@ The Merkle tree MUST be computable in streaming fashion without storing all leaf
 4. Total hash operations: `2^(h+1) - 1` (`2^h` leaf hashes + `2^h - 1` internal hashes).
 
 ```python
-def compute_merkle_root_streaming(base: int, height: int) -> bytes:
+def compute_merkle_root_streaming(seed_prefix: bytes, base: int, height: int) -> bytes:
     """Compute Merkle root over aligned subtree in O(h) memory."""
     if height == 0:
-        return sha256(SIDESTEP_DOMAIN + int_to_bytes_be_min(base))
+        return sha256(seed_prefix + int_to_bytes_be_min(base))
 
     stack = []  # (hash_value, level)
     for i in range(1 << height):
         leaf_bytes = int_to_bytes_be_min(base + i)
-        current = sha256(SIDESTEP_DOMAIN + leaf_bytes)
+        current = sha256(seed_prefix + leaf_bytes)
         level = 0
         while stack and stack[-1][1] == level:
             left = stack.pop()[0]
@@ -697,6 +717,10 @@ def compute_merkle_root_streaming(base: int, height: int) -> bytes:
 ```
 
 (Implementations MAY use any equivalent algorithm; the result MUST match this definition.)
+
+**Midstate optimization (normative for performance, not for consensus):** `seed_prefix` is exactly 64 bytes and constant for the whole tree, so it fills exactly one SHA-256 block. Implementations SHOULD precompute the compression-function midstate over that block once per axis and resume from it for every leaf. Because `leaf_bytes` is at most 11 bytes and SHA-256 padding needs 9, each leaf then costs exactly one further compression, which is the same per-leaf cost as an unseeded leaf. The figures in §6.14 are therefore unchanged by seeding.
+
+Had `seed_prefix` not been padded to a block boundary, each leaf would have straddled two blocks and every sidestep in the protocol would have cost twice as much. Implementations that ignore the midstate optimization are still consensus-correct; they are simply half as fast.
 
 ### 6.6 Spatial region integer (region_m)
 
@@ -723,9 +747,11 @@ The temporal binding mechanism for sidesteps is **identical** to hop proofs (§5
 
 This is always feasible because `K ≤ 16` (maximum 65,536 Cantor pairs, ~100 ms).
 
-**Why temporal binding is required:** Without it, the spatial Merkle root is deterministic and replayable. Anyone who computes it once could claim repeated crossings without new work. The temporal axis, seeded by `previous_event_id`, binds each proof to a unique chain position.
+**Why temporal binding is retained:** In v1 of the sidestep construction the temporal axis was the *only* thing binding a proof to a chain position, because the spatial Merkle root was deterministic and replayable. Since §6.4 now seeds the spatial leaves with `previous_event_id`, replay protection is already provided by the spatial component. The temporal axis is retained because it carries the terrain-derived height `K` (§5.2), which is a property of the destination and not of the mover, and because it keeps sidestep and hop proofs structurally parallel. It is no longer load-bearing for replay.
 
-**Precomputation note (non-normative):** An entity MAY precompute the spatial Merkle root as preparation for a planned crossing. The temporal component must still be computed fresh at crossing time (since `previous_event_id` is only known after the preceding event is published). This is acceptable because the spatial component is where all the real work is.
+**No precomputation (normative consequence):** Because `seed_prefix` depends on `previous_event_id`, which is only known once the preceding event is published, the spatial Merkle root cannot be computed in advance of a crossing. An entity MUST perform the full spatial work between publishing its previous event and publishing the sidestep. This is the intended behaviour: it is what makes the cost in §6.14 a toll rather than a one-time preparation that can be amortized or scheduled.
+
+**Resumption (non-normative):** A crossing at h47 or above is hours of GPU work that can no longer be staged ahead of time, so an interrupted crossing is expensive to lose. Implementations SHOULD persist completed subtree state keyed by `(previous_event_id, axis_byte, base, h)` so an interrupted sidestep resumes rather than restarting. The seeding of §6.4 makes this safe: cached state is only ever valid for the one chain position it was computed under, so it can never be replayed into a later crossing. This mirrors `decks/DECK-0001-hyperspace.md` §5.7.
 
 ### 6.8 Sidestep proof hash (normative)
 
@@ -754,39 +780,66 @@ A single sidestep event MAY cross boundaries on multiple axes simultaneously (if
 - Temporal binding applies once to the combined proof, not per-axis.
 - The total work is the sum of per-axis work.
 
-### 6.10 Merkle inclusion proof
+### 6.10 Openings (normative)
 
-In addition to the Merkle root, the prover MUST publish a Merkle inclusion proof for the destination leaf on each axis where movement occurs. This enables efficient verification (see §6.11).
+In addition to the Merkle root, the prover MUST publish, for each axis where movement occurs, an inclusion proof for the destination leaf **and** `SIDESTEP_SAMPLES` inclusion proofs at pseudorandomly sampled positions.
 
-Each per-axis inclusion proof is a sequence of sibling hashes from leaf to root:
+Each inclusion proof is a sequence of sibling hashes from leaf to root:
 
 ```
 axis_proof = H_sibling_0 || H_sibling_1 || ... || H_sibling_{h-1}
 ```
 
-Where `H_sibling_i` is the 32-byte sibling hash at depth `i` (leaf = depth 0). The verifier determines left/right ordering at each level from the destination leaf's position in the subtree (deterministic from the leaf value).
+Where `H_sibling_i` is the 32-byte sibling hash at depth `i` (leaf = depth 0). The verifier determines left/right ordering at each level from the leaf's position in the subtree (deterministic from the leaf value).
 
-For trivial axes (`h = 0`), the inclusion proof is empty: the Merkle root IS the single leaf hash.
+**Sample indices.** For an axis with root `M_axis`, height `h`, and `axis_byte` as in §6.4, the sampled positions are, for `i` in `0 .. SIDESTEP_SAMPLES - 1`:
+
+```
+idx_i = int(SHA256(SIDESTEP_SAMPLE_DOMAIN || M_axis || axis_byte || be32(i))) mod 2^h
+```
+
+`be32(i)` is `i` as four big-endian bytes. Indices are positions within the aligned subtree, so the sampled leaf value is `base + idx_i`. Indices MAY collide; implementations MUST NOT deduplicate, so that the opening count is fixed and the encoding in §8.5 is fixed-width.
+
+**Constants (normative):**
+```
+SIDESTEP_SAMPLE_DOMAIN = b"CYBERSPACE_SIDESTEP_SAMPLE_V1"
+SIDESTEP_SAMPLES       = 8
+```
+
+**Ordering.** The openings for an axis are ordered: the destination proof first, then the sampled proofs in ascending `i`. Each is exactly `h` sibling hashes, so an axis contributes exactly `(SIDESTEP_SAMPLES + 1) × h × 32` bytes.
+
+**Trivial axes (`h = 0`):** no openings are published. The Merkle root IS the single leaf hash and there is nothing to sample.
+
+**Why sampling is required (normative rationale):** The destination inclusion proof alone proves only that the destination leaf sits in *some* tree with the claimed root. It does not prove the tree was built over the aligned subtree, and it never did. A prover can fabricate `h` arbitrary sibling hashes, hash upward from the genuine destination leaf, and publish the result: `h` hash operations instead of `2^h`, passing the destination check exactly.
+
+Under the v1 unseeded construction this gap was survivable, because every honest root for a boundary was the same 32 bytes, so any party holding that root detected the forgery by comparison, and no rational prover forged when copying was free and correct. Seeding removes the copy, and with it removes comparison auditing: after §6.4 there is no canonical root to compare a claim against, and only a full `O(2^h)` recomputation would catch a fabricated tree. Seeding without sampling would therefore be strictly worse than the design it replaces. The two changes MUST ship together.
 
 ### 6.11 Verification levels
 
 Sidestep verification has two levels, reflecting a trade-off between verification cost and trust assumptions:
 
-**Level 1: Inclusion path verification, O(h) per axis**
+**Level 1: Sampled opening verification, O(SIDESTEP_SAMPLES × h) per axis**
 
-A verifier checks that the claimed destination leaf is consistent with the claimed Merkle root:
+A verifier checks that the claimed openings are consistent with the claimed root and that the sampled leaves are the correct seeded values:
 
 1. Validate coordinates: source and destination are valid 256-bit Cyberspace coordinates.
 2. Validate crossing geometry per §6.3: on every axis where movement occurs, `h = find_lca_height(v1, v2)`, the source touches the wall on its side (`base + half - 1` going up, `base + half` going down), and the destination is exactly 1 Gibson past it; axes without movement have `v1 == v2`.
-3. Recompute destination leaf hash: `H_dest = SHA256(SIDESTEP_DOMAIN || int_to_bytes_be_min(v_dest))`
-4. Verify Merkle path from `H_dest` to claimed root `M_axis` using inclusion proof.
-5. Recompute `region_m`, temporal axis, and `proof_hash`. Compare against claimed value.
+3. Reconstruct `seed_prefix` from the event's `e previous` tag and `axis_byte` per §6.4.
+4. Recompute the destination leaf hash `H_dest = SHA256(seed_prefix || int_to_bytes_be_min(v_dest))` and verify its path to the claimed root `M_axis`.
+5. Derive the sample indices from `M_axis` per §6.10. For each, recompute the sampled leaf hash `SHA256(seed_prefix || int_to_bytes_be_min(base + idx_i))` from scratch and verify its path to `M_axis`.
+6. Recompute `region_m`, temporal axis, and `proof_hash`. Compare against claimed value.
+
+Level 1 costs `SIDESTEP_SAMPLES + 1` leaf hashes and the same number of paths, seconds at any height.
 
 **Level 2: Full root verification, O(2^h) per axis**
 
 To fully verify that the claimed Merkle root was computed over the correct aligned subtree, a verifier recomputes the entire Merkle tree from scratch. This costs the same order of work as the original proof.
 
-**Security model:** The protocol does NOT require every verifier to perform Level 2. Security relies on **deterministic fraud detectability**: the Merkle root for any aligned subtree is deterministic, so a fraudulent root is permanently and objectively detectable by any party willing to do the work. Since sidestep proofs are published on Nostr (public, persistent), fraud can be detected at any time.
+**Security model:** The protocol does NOT require every verifier to perform Level 2. Security relies on **deterministic fraud detectability**: the Merkle root for an aligned subtree is a deterministic function of `(previous_event_id, axis_byte, base, h)`, every one of which is public on the event itself, so a fraudulent root remains permanently and objectively detectable by any party willing to do the work. Seeding changes who bears the audit cost, not whether fraud is detectable. Under v1 an auditor could compute a boundary's root once and check every crossing of it forever; under v2 each event must be audited on its own, which is why Level 1 was strengthened from a single destination path to sampled openings.
+
+**What sampling bounds (non-normative).** A tree over `2^h` leaves requires `2^h` leaf hashes and `2^h - 1` internal hashes, so the internal tree is an irreducible half of the honest work and no prover can avoid it. A prover who honestly computes a fraction `f` of the leaves and fabricates the rest passes Level 1 with probability `f^SIDESTEP_SAMPLES`, because the sampled positions are spread pseudorandomly over the whole subtree and each sampled leaf is recomputed by the verifier from the public seed. Grinding is not an escape: the sample indices are derived from the root, so steering them requires rebuilding the tree, and each rebuild costs at least the `2^h - 1` internal hashes, which is half the honest total.
+
+With `SIDESTEP_SAMPLES = 8`, passing half the time requires honestly computing about 92 percent of the leaves. Skipping the other 8 percent saves about 4 percent of the crossing's total work, since the internal tree is untouched, and buys a one-in-two chance of publishing permanently detectable fraud that invalidates the chain from that event forward. A prover willing to accept a one-in-a-thousand pass rate still has to compute 42 percent of the leaves, saving 29 percent. The security margin here comes primarily from the rebuild cost, not from the sample count, which is why 8 suffices where `decks/DECK-0001-hyperspace.md` §5.5 needs 32: a hyperspace leaf is expensive and its tree is cheap, and a sidestep is the reverse.
 
 In practice, Level 1 is for routine validation. Level 2 is for auditors, competitors, or automated fraud-detection services.
 
@@ -798,6 +851,14 @@ This preserves a critical separation: **sidestepping into a region does not yiel
 
 This is desirable: it creates a natural asymmetry between those who hold a region (who have invested in Cantor computation and keep its keys, §7.8) and visitors (who have done the minimum work to cross the boundary). Holding is a capability, not a title: anyone who does the work holds the same keys, and no one is excluded. There are no domains in the base protocol; `RATIONALE.md` §6 says what holding does and does not buy, and `docs/territory-conflict-game-layer.md` records the design decision.
 
+**A crossing cannot be sold; a root can (non-normative).** After §6.4 the two primitives are priced on opposite principles, deliberately.
+
+A sidestep is a **toll on an edge**. Its proof is seeded to one chain position, so it is worth nothing to anyone else. There is no market in crossings, no pioneer subsidising later travellers, and no way to buy a wall crossing except by paying for it yourself.
+
+A hop is a **canonical price on a cell**. Its work product is the region root of §4.6, whose hash is the region key of §7.2, and the one property that makes region keys work at all is canonical convergence (§4.9, property 4): two parties at the same place derive the same key without meeting. That property is what makes a key issuer-free, and it cannot survive seeding. A consequence is that an identity handed a region root can produce a hop across the corresponding boundary for the cost of the temporal axis alone, roughly 100 ms, at any height.
+
+This is not an oversight and it is not a road in the sense §6.4 forbids. A region root is disclosed only when a holder chooses to disclose it, one recipient at a time, and that disclosure is exactly the act the protocol is built to support: handing someone the key to a place. The v1 sidestep published the equivalent to the whole world automatically, as a side effect of one traveller moving, with nobody choosing anything. Movement is priced; disclosure is a social act.
+
 ### 6.13 Natural continents (non-normative)
 
 The combination of Cantor hops and Merkle sidesteps creates emergent geography in the coordinate space:
@@ -806,6 +867,8 @@ The combination of Cantor hops and Merkle sidesteps creates emergent geography i
 - **h20–50:** Crossable by sidestep on consumer hardware (seconds to days on a GPU).
 - **h50–58:** Crossable by sidestep with a rented-GPU budget of roughly $20 to $3,000.
 - **h60+:** Not crossable by consumer computation. Crossable by ASIC-scale hash work (a 1 EH/s farm crosses h78 in about a week; a Bitcoin-scale fleet crosses h85 in about a day). Hyperspace (DECK-0001) is the consumer route.
+
+These prices are per traveller and per crossing. Because §6.4 seeds every sidestep tree to its mover's chain position, a boundary that costs three GPU hours costs three GPU hours for the first identity to cross it and three GPU hours for the ten thousandth. The continents below are therefore a description of the space as every agent actually experiences it, rather than a description of what the first arrival paid.
 
 Nobody designed these continents. They emerge from the interaction between the Cantor pairing function, SHA-256, and the physical limits of computation and storage. Different agents experience different continental boundaries depending on their hardware and patience. There is no single universal map of "passable" and "impassable" walls.
 
@@ -828,6 +891,18 @@ Sidestep cost is dominated by SHA-256 leaf hashing and is fixed-size per leaf. H
 | h85 | not feasible | 2.5×10¹⁰ y | 1.1×10⁸ y | Bitcoin-scale ASIC fleet: about a day |
 
 The practical consumer sidestep ceiling is about h55 per axis for a thousand dollars of rented GPU time. Sidestep work is plain SHA-256 over short preimages and is therefore subject to ASIC acceleration; the storage bound of §13.2 applies to Cantor roots, not to travel. Beyond consumer reach, hyperspace (DECK-0001) is the route.
+
+Every figure in this table is now what each traveller pays on each crossing, and none of it can be prepared in advance (§6.7). The openings of §6.10 cost `(SIDESTEP_SAMPLES + 1) × h × 32` bytes per non-trivial axis, which the `mp` tag carries as hex and so doubles: about 11 KB of tag text at h20, 23 KB at h40, and 26 KB at h47 for a single-axis crossing. A three-axis crossing at h47 approaches 80 KB and at h55 approaches 93 KB. Implementations SHOULD confirm their relays' event size limits before attempting multi-axis crossings above h40.
+
+### 6.15 Version 2 of the sidestep construction (normative)
+
+The seeding of §6.4, the axis separation of §6.4, and the sampled openings of §6.10 are a breaking change to sidestep verification. They were adopted together because seeding without sampling is strictly worse than the construction it replaces (§6.10).
+
+- `SIDESTEP_DOMAIN` is bumped from `CYBERSPACE_SIDESTEP_V1` to `CYBERSPACE_SIDESTEP_V2`, so no v1 proof can be mistaken for a v2 proof or collide with one.
+- Verifiers implementing this revision MUST reject sidestep events built under the v1 construction. There is no grace period and no dual-acceptance mode: accepting v1 proofs would keep the pioneer-priced path open, which is the entire defect being repaired.
+- Chains containing a v1 sidestep are invalidated from that event forward and must respawn. At adoption this affected three events published by two identities, all single-axis crossings at h19 and h20, which is why no migration path was specified.
+
+Implementations of the base protocol prior to this revision computed leaves as `SHA256(b"CYBERSPACE_SIDESTEP_V1" || leaf_bytes)` with no seed and no axis separation, and published a single destination inclusion path. Those proofs are recognisable by their `mp` tag carrying exactly one path per axis rather than `SIDESTEP_SAMPLES + 1`.
 
 ---
 
@@ -1140,13 +1215,15 @@ Required tags:
 - `C` tag: `["C", "<coord_hex>"]` (32-byte lowercase hex string)
 - `proof` tag: `["proof", "<proof_hash_hex>"]` (32-byte lowercase hex string)
 - `mr` tag: `["mr", "<M_x_hex>:<M_y_hex>:<M_z_hex>"]` (per-axis Merkle roots, colon-separated, each 64 hex chars)
-- `mp` tag: `["mp", "<proof_x_hex>:<proof_y_hex>:<proof_z_hex>"]` (per-axis Merkle inclusion proofs, colon-separated)
+- `mp` tag: `["mp", "<openings_x_hex>:<openings_y_hex>:<openings_z_hex>"]` (per-axis openings, colon-separated)
 - `hx` tag: `["hx", "<lca_height_x>"]` (LCA height on X axis, decimal string)
 - `hy` tag: `["hy", "<lca_height_y>"]` (LCA height on Y axis, decimal string)
 - `hz` tag: `["hz", "<lca_height_z>"]` (LCA height on Z axis, decimal string)
 - Sector tags: `X`, `Y`, `Z`, `S` (per §10)
 
-**Merkle inclusion proof encoding:** Each per-axis proof in the `mp` tag is a concatenation of sibling hashes from leaf to root, hex-encoded (`64 × h` hex characters per axis for an axis with LCA height `h`). For trivial axes (`h = 0`), the proof segment is an empty string between colons.
+**Openings encoding:** Each per-axis segment in the `mp` tag is the concatenation of `SIDESTEP_SAMPLES + 1` inclusion proofs in the order defined by §6.10 (destination first, then samples in ascending `i`). Each proof is `h` sibling hashes from leaf to root, hex-encoded, so an axis with LCA height `h` contributes exactly `64 × h × (SIDESTEP_SAMPLES + 1)` hex characters. For trivial axes (`h = 0`), the segment is an empty string between colons.
+
+Because the segment is fixed-width given `h`, a verifier reads the per-axis `hx`, `hy`, `hz` tags and splits the segment without ambiguity. A segment whose length is not an exact multiple of `64 × h` is malformed and the event MUST be rejected; a segment of exactly `64 × h` characters is a v1 proof and MUST be rejected per §6.15.
 
 **Height tags:** The `hx`, `hy`, `hz` tags enable verifiers to determine expected proof lengths without re-deriving LCA heights from coordinates.
 
@@ -1184,20 +1261,23 @@ To verify a hop:
 7. Compute `proof_hash` per §5.6.
 8. Accept iff it matches the event's `proof` tag.
 
-#### 8.7.2 Sidestep verification (Level 1: inclusion path)
+#### 8.7.2 Sidestep verification (Level 1: sampled openings)
 
-To verify a sidestep (Level 1, inclusion path check):
+To verify a sidestep (Level 1, sampled openings check):
 1. Parse previous and current coords; decode to `(x1,y1,z1,plane)` and `(x2,y2,z2,plane)`.
 2. Validate crossing geometry: for each axis, confirm the destination is exactly 1 Gibson past the LCA boundary (§6.3). Verify the `hx`, `hy`, `hz` tags match the computed LCA heights.
-3. Parse per-axis Merkle roots from the `mr` tag.
+3. Parse per-axis Merkle roots from the `mr` tag. Read `previous_event_id` from the `e` tag with marker `previous`.
 4. For each axis where movement occurs:
-   a. Compute the destination leaf hash: `H_dest = SHA256(SIDESTEP_DOMAIN || int_to_bytes_be_min(v_dest))`
-   b. Parse the axis inclusion proof from the `mp` tag.
-   c. Verify the Merkle path from `H_dest` to the claimed root `M_axis`.
+   a. Build `seed_prefix = SIDESTEP_DOMAIN || previous_event_id || axis_byte || SEED_PAD` per §6.4, and the aligned base `base = (v1 >> h) << h`.
+   b. Split the axis segment of the `mp` tag into `SIDESTEP_SAMPLES + 1` proofs of `h` siblings each; reject if the length does not match (§8.5).
+   c. Compute the destination leaf hash `H_dest = SHA256(seed_prefix || int_to_bytes_be_min(v_dest))` and verify its path to the claimed root `M_axis`.
+   d. Derive the sample indices from `M_axis` per §6.10. For each `idx_i`, compute `SHA256(seed_prefix || int_to_bytes_be_min(base + idx_i))` and verify its path to `M_axis`.
 5. Compute `region_m = π(π(mx, my), mz)` from the claimed Merkle roots (§6.6).
 6. Derive `K` and `cantor_t` from destination coordinate and `previous_event_id` (§6.7, same as hop).
 7. Compute `sidestep_n = π(region_m, cantor_t)` and `proof_hash` per §6.8.
 8. Accept iff it matches the event's `proof` tag.
+
+A verifier that skips step 4d is performing a strictly weaker check than v1's, not an equivalent one, because after seeding there is no canonical root to compare `M_axis` against (§6.10).
 
 Level 2 (full root) verification is described in §6.11.
 
@@ -1522,6 +1602,8 @@ The sidestep (§6), which uses SHA-256 Merkle hash trees instead of Cantor pairi
 
 This creates an interesting layering: Cantor hops are storage-bound structured work (fast but limited by storage), while Merkle sidesteps are compute-bound hash work (slow but unlimited by storage). The protocol naturally routes movement through whichever regime is feasible for the boundary being crossed.
 
+The two also differ in what the work leaves behind, and the difference is deliberate (§6.12). A Cantor hop's output is durable public infrastructure: a canonical region root that anyone may be handed and reuse. A Merkle sidestep's output is consumed at the moment of use: seeded to one chain position, worth nothing to anyone else, and disposable in exactly the way §13.1 says a Bitcoin hash is disposable. The sidestep is the one place in Cyberspace where work is burned rather than accumulated, which is precisely what makes it a price on movement instead of an investment in a place.
+
 ---
 
 ## 14. Reference Implementation
@@ -1534,4 +1616,7 @@ Implementers should treat that repo as the reference for:
 - Movement proof computation
 - Canonical GPS→dataspace mapping (`CANONICAL_GPS_TO_DATASPACE_SPEC_VERSION` and golden vectors)
 
-`hint-reference.py` in this repository is a stdlib-only executable statement of §7.7 and the §10 rule for bags. Running it checks canonical form, containment, sector tags, seeker work, malformed hints and plane preservation, and locks the golden vectors of §7.7.
+This repository also carries stdlib-only reference scripts that are executable statements of specific sections, each self-checking when run:
+- `sidestep-reference.py` — the v2 sidestep construction (§6.4, §6.5, §6.10, §6.11), with golden vectors and a check that each property those sections claim actually holds
+- `hint-reference.py` — §7.7 and the §10 rule for bags: canonical form, containment, sector tags, seeker work, malformed hints and plane preservation, locking the golden vectors of §7.7
+- `decks/landfall-reference.py` — landfall derivation (DECK-0001 §1.2)

--- a/sidestep-reference.py
+++ b/sidestep-reference.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""CYBERSPACE_V2 section 6: reference sidestep v2 construction (stdlib only).
+
+The v2 sidestep is a *toll*: its Merkle tree is seeded by the mover's chain
+position, so no traveller's published proof reduces the cost for any other.
+This file is the executable statement of sections 6.4, 6.5, 6.10 and 6.11, and
+running it checks the properties those sections claim:
+
+  1. two movers crossing the same boundary produce different roots
+  2. a copied root and openings fail under the copier's own seed (no roads)
+  3. an honest proof passes Level 1
+  4. the axis byte separates identical subtrees on different axes
+  5. a fabricated tree passes a destination-only check, as v1's did
+  6. the same fabricated tree fails sampled openings, which is why 6.10 exists
+  7. a trivial axis root is the single seeded leaf
+  8. seed_prefix is exactly one SHA-256 block, so seeding costs no extra
+     compression per leaf (section 6.5)
+
+Golden vectors at the bottom lock the construction for other implementations.
+"""
+import hashlib
+
+SIDESTEP_DOMAIN = b"CYBERSPACE_SIDESTEP_V2"        # 22 bytes
+SEED_PAD = b"\x00" * 9                             # to a 64-byte block
+SIDESTEP_SAMPLE_DOMAIN = b"CYBERSPACE_SIDESTEP_SAMPLE_V1"
+SIDESTEP_SAMPLES = 8
+AXIS_X, AXIS_Y, AXIS_Z = 0x00, 0x01, 0x02
+
+
+def sha256(b: bytes) -> bytes:
+    return hashlib.sha256(b).digest()
+
+
+def int_to_bytes_be_min(n: int) -> bytes:
+    return n.to_bytes(max(1, (n.bit_length() + 7) // 8), "big")
+
+
+def seed_prefix(previous_event_id: bytes, axis_byte: int) -> bytes:
+    """Section 6.4. Exactly 64 bytes: one SHA-256 block."""
+    if len(previous_event_id) != 32:
+        raise ValueError("previous_event_id must be 32 raw bytes")
+    prefix = SIDESTEP_DOMAIN + previous_event_id + bytes([axis_byte]) + SEED_PAD
+    assert len(prefix) == 64
+    return prefix
+
+
+def leaf_hash(prefix: bytes, value: int) -> bytes:
+    return sha256(prefix + int_to_bytes_be_min(value))
+
+
+def merkle_root_streaming(prefix: bytes, base: int, height: int) -> bytes:
+    """Section 6.5, in O(h) memory."""
+    if height == 0:
+        return leaf_hash(prefix, base)
+    stack = []  # (hash, level)
+    for i in range(1 << height):
+        current, level = leaf_hash(prefix, base + i), 0
+        while stack and stack[-1][1] == level:
+            current = sha256(stack.pop()[0] + current)
+            level += 1
+        stack.append((current, level))
+    return stack[0][0]
+
+
+def _levels(prefix: bytes, base: int, height: int):
+    level = [leaf_hash(prefix, base + i) for i in range(1 << height)]
+    out = [level]
+    while len(level) > 1:
+        level = [sha256(level[j] + level[j + 1]) for j in range(0, len(level), 2)]
+        out.append(level)
+    return out
+
+
+def inclusion_path(prefix: bytes, base: int, height: int, idx: int) -> list:
+    """Sibling hashes from leaf to root (section 6.10)."""
+    levels, out, i = _levels(prefix, base, height), [], idx
+    for depth in range(height):
+        out.append(levels[depth][i ^ 1])
+        i //= 2
+    return out
+
+
+def verify_path(leaf: bytes, idx: int, siblings: list, root: bytes) -> bool:
+    cur, i = leaf, idx
+    for sib in siblings:
+        cur = sha256(cur + sib) if i % 2 == 0 else sha256(sib + cur)
+        i //= 2
+    return cur == root
+
+
+def sample_indices(root: bytes, axis_byte: int, height: int) -> list:
+    """Section 6.10. Indices are positions within the aligned subtree."""
+    return [
+        int.from_bytes(
+            sha256(SIDESTEP_SAMPLE_DOMAIN + root + bytes([axis_byte]) + i.to_bytes(4, "big")),
+            "big",
+        ) % (1 << height)
+        for i in range(SIDESTEP_SAMPLES)
+    ]
+
+
+def prove_axis(previous_event_id: bytes, axis_byte: int, v1: int, v2: int):
+    """Full per-axis sidestep proof. Returns (root, openings, base, height)."""
+    height = (v1 ^ v2).bit_length()
+    base = (v1 >> height) << height
+    prefix = seed_prefix(previous_event_id, axis_byte)
+    root = merkle_root_streaming(prefix, base, height)
+    if height == 0:
+        return root, [], base, height
+    openings = [inclusion_path(prefix, base, height, v2 - base)]
+    openings += [inclusion_path(prefix, base, height, i)
+                 for i in sample_indices(root, axis_byte, height)]
+    return root, openings, base, height
+
+
+def verify_axis(previous_event_id, axis_byte, v1, v2, root, openings) -> bool:
+    """Level 1 (section 6.11): destination path plus sampled openings."""
+    height = (v1 ^ v2).bit_length()
+    base = (v1 >> height) << height
+    prefix = seed_prefix(previous_event_id, axis_byte)
+    if height == 0:
+        return root == leaf_hash(prefix, v1) and not openings
+    if len(openings) != SIDESTEP_SAMPLES + 1:
+        return False
+    if any(len(p) != height for p in openings):
+        return False
+    if not verify_path(leaf_hash(prefix, v2), v2 - base, openings[0], root):
+        return False
+    for path, idx in zip(openings[1:], sample_indices(root, axis_byte, height)):
+        if not verify_path(leaf_hash(prefix, base + idx), idx, path, root):
+            return False
+    return True
+
+
+if __name__ == "__main__":
+    import os
+
+    H, AXIS = 12, AXIS_Z
+    base = (0x1234567 >> H) << H
+    v1, v2 = base, base + (1 << H)      # destination per section 6.3
+    alice, bob = bytes(range(32)), bytes(range(32, 64))
+
+    root_a, open_a, _, _ = prove_axis(alice, AXIS, v1, v2)
+    root_b, _, _, _ = prove_axis(bob, AXIS, v1, v2)
+    pa = seed_prefix(alice, AXIS)
+
+    checks = [
+        ("roots differ across movers at one boundary", root_a != root_b),
+        ("copied proof fails under the copier's seed",
+         not verify_axis(bob, AXIS, v1, v2, root_a, open_a)),
+        ("honest Level 1 verifies", verify_axis(alice, AXIS, v1, v2, root_a, open_a)),
+        ("axis byte separates identical subtrees",
+         prove_axis(alice, AXIS_X, v1, v2)[0] != root_a),
+    ]
+
+    # v1's destination-only check accepted a tree that was never built.
+    fake_sibs = [sha256(b"forge" + bytes([i])) for i in range(H)]
+    cur, i = leaf_hash(pa, v2), v2 - base
+    for s in fake_sibs:
+        cur = sha256(cur + s) if i % 2 == 0 else sha256(s + cur)
+        i //= 2
+    fake_root = cur
+    checks += [
+        ("fabricated root passes a destination-only check",
+         verify_path(leaf_hash(pa, v2), v2 - base, fake_sibs, fake_root)),
+        ("fabricated root fails sampled openings",
+         not verify_axis(alice, AXIS, v1, v2, fake_root,
+                         [fake_sibs] * (SIDESTEP_SAMPLES + 1))),
+        ("trivial axis root is the single seeded leaf",
+         prove_axis(alice, AXIS, 999, 999)[0] == leaf_hash(pa, 999)),
+        ("seed_prefix is exactly one SHA-256 block", len(pa) == 64),
+        ("an 85-bit axis value fits the second block",
+         len(int_to_bytes_be_min((1 << 85) - 1)) + 9 <= 64),
+    ]
+
+    # Golden vectors (consensus locks for other implementations).
+    zero = bytes(32)
+    golden = [
+        (zero, AXIS_X, 0, 0),
+        (zero, AXIS_Z, base, base + (1 << 4)),
+        (bytes(range(32)), AXIS_Y, 1 << 40, (1 << 40) + (1 << 8)),
+    ]
+    print("golden vectors (previous_event_id, axis, v1, v2) -> root")
+    for prev, axis, a, b in golden:
+        r, _, _, h = prove_axis(prev, axis, a, b)
+        print(f"  {prev.hex()[:16]}… axis={axis} h={h:2d} -> {r.hex()}")
+    print()
+
+    width = max(len(n) for n, _ in checks)
+    for name, ok in checks:
+        print(f"  {name.ljust(width)}  {'ok' if ok else 'FAIL'}")
+    if not all(ok for _, ok in checks):
+        raise SystemExit(1)
+    print("\nall checks passed")


### PR DESCRIPTION
## The defect

The v1 sidestep leaf preimage is `SHA256(SIDESTEP_DOMAIN || leaf_bytes)`. It carries no identity and no chain context, so the Merkle root for an aligned subtree is the same 32 bytes for every traveller, forever.

Combine that with a deterministic destination (§6.3) and roots plus openings published in the clear (§8.5), and the first identity to cross any boundary publishes everything a later identity needs. A follower copies `mr` and `mp` off a relay, spends ~100 ms on the temporal axis, and produces a proof that passes Level 1 **and** Level 2, because the copied root *is* the correct root.

Every price in §6.14 was a pioneer's price. The 3 GPU hour last mile to any place on Earth was paid once in the history of the world, and was a rounding error for everyone after. §6.7 stated the assumption that made it possible: precomputation is fine "because the spatial component is where all the real work is". §6.12 and §6.13 meanwhile describe walls and continents as though every crossing were paid. The protocol had roads while its prose assumed tolls.

## The fix

Leaves are seeded with `previous_event_id` and an axis byte, padded to **exactly one SHA-256 block** so the compression midstate absorbs the prefix and the per-leaf cost is unchanged. Without that padding the prefix would be 55 bytes, every leaf would straddle two blocks, and every sidestep in the protocol would have cost twice as much.

The axis byte is not cosmetic. Earth is centred at exactly `2^84` on every axis, which is a multiple of `2^h` for every `h ≤ 84`, so above about h56 the aligned base takes one of two values per axis and any two axes on the same side of centre share it. Without separation a multi-axis crossing computes one tree and claims three, exactly where the work is largest.

## Why seeding alone would have been worse than v1

The old Level 1 never checked any leaf but the destination. A prover can fabricate `h` sibling hashes, hash upward from the genuine destination leaf, and publish the result: `h` operations instead of `2^h`. That gap exists today and is survivable only because every honest root for a boundary is identical, so anyone holding it catches the forgery by comparison, and no rational prover forges when copying is free and correct.

Seeding removes the copy, and with it removes comparison auditing. Ship it alone and forgery costs 47 hashes at h47 while detection costs `2^48`.

So §6.10 replaces the single destination path with **sampled openings**: 8 positions derived from the root, each leaf recomputed by the verifier from the public seed. A prover who honestly computes fraction `f` passes with probability `f^8`, and grinding the indices means rebuilding the tree, which costs at least the `2^h - 1` internal hashes: half the honest total. Cheating is bounded at about 4% saving for a coin flip on permanently detectable fraud.

8 samples suffice where DECK-0001 §5.5 needs 32, because a hyperspace leaf is expensive and its tree is cheap, and a sidestep is the reverse.

Deterministic fraud detectability survives intact. The root is still a pure function of public inputs. What changes is that audits no longer amortize across travellers, which is the point.

## Hops are deliberately untouched

A hop's work product is the canonical region root whose hash is the region key (§7.2), and canonical convergence (§4.9 property 4) is the one property that makes region keys issuer-free. It cannot survive seeding.

So an identity handed a region root can still cross the corresponding boundary for ~100 ms at any height. That is not the same defect: a root is disclosed only when a holder chooses to disclose it, one recipient at a time. The v1 sidestep published the equivalent to the whole world automatically, as a side effect of one traveller moving, with nobody choosing anything. Movement is priced; disclosure is a social act. §6.12 now says so explicitly.

## Breaking change

No grace period and no dual-acceptance mode: accepting v1 proofs keeps the pioneer-priced path open, which is the whole defect.

Blast radius measured against `cyberspace.nostr1.com`: **three** sidestep events, ever, from two identities, all single-axis at h19 and h20. The rest of the live corpus is 172 spawns, 123 hops, 14 enter-hyperspace, 6 hyperjumps, and 1,659 v1-era `drift`/`noop` events that carry no Merkle proof.

## Contents

- §6.2 terms, toll and openings defined
- §6.4 seeded leaves, axis byte, block-aligned prefix, both rationales
- §6.5 midstate optimization
- §6.7 precomputation is now impossible; resumption guidance mirroring DECK-0001 §5.7; temporal binding demoted from load-bearing to structural
- §6.10 sampled openings replace the destination-only path
- §6.11 Level 1 rewritten, security model rewritten, cheating bound, L1/L2 crossover near h5
- §6.12 why a crossing cannot be sold but a root can
- §6.13, §6.14 prices are now per traveller; opening sizes
- §6.15 migration
- §8.5, §8.7.2 tag encoding and verification
- §13.5 the sidestep is the one place work is burned rather than accumulated
- `sidestep-reference.py`: stdlib-only, self-checking, golden vectors, and an executable demonstration of both the roads attack and the fabricated-tree attack

Run `python3 sidestep-reference.py` to check it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEixRgFR5Dej5imcEQE4sG