### PR TITLE
Hints: a bag may say where it can be found (§7.6)

### DIFF
--- a/CYBERSPACE_V2.md
+++ b/CYBERSPACE_V2.md
@@ -1,7 +1,7 @@
 # Cyberspace v2: Protocol Specification
 
 **Date:** February 10, 2026
-**Last updated:** August 24, 2026
+**Last updated:** September 1, 2026
 **Status:** Design complete (spec); reference implementation in progress
 
 ---
@@ -85,6 +85,7 @@ For extended design rationale and philosophical discussion, see [`RATIONALE.md`]
   - [7.3 Discovery radius (non-normative)](#73-discovery-radius-non-normative)
   - [7.4 Discovery scanning (recommended)](#74-discovery-scanning-recommended)
   - [7.5 Caching optimization (non-normative)](#75-caching-optimization-non-normative)
+  - [7.6 Hints (optional)](#76-hints-optional)
 - [8. Nostr Integration: The Movement Chain](#8-nostr-integration-the-movement-chain)
   - [8.1 Event kind](#81-event-kind)
   - [8.2 Canonical event id (NIP-01)](#82-canonical-event-id-nip-01)
@@ -862,7 +863,7 @@ At the Cantor Height 34 scale (2 meters per height-34 subtree), approximate phys
 
 A local secret at height 34 is discoverable within ~2 meters. At height 50, from anywhere in a city.
 
-**Important caveat:** Discovery requires *equivalent computation* to secret creation. Typical scanning range is between height 0 and 16 for sub-second continuous scanning on average consumer hardware. Secrets at larger regions may be unattainable without some hint to help users scan up to their height. As hardware improves, passive scanning range will grow and larger secret regions will become attainable.
+**Important caveat:** Discovery requires *equivalent computation* to secret creation. Typical scanning range is between height 0 and 16 for sub-second continuous scanning on average consumer hardware. Secrets at larger regions may be unattainable without some hint to help users scan up to their height. Hints are specified in §7.6: the hider MAY publish the aligned box a bag lies in, one height per axis, and a seeker sweeps that box instead of the whole space. As hardware improves, passive scanning range will grow and larger secret regions will become attainable.
 
 The discovery radius grows exponentially with height, enabling a natural hierarchy of public, neighborhood, and intimate spatial messages.
 
@@ -940,6 +941,77 @@ def get_region_key(x, y, z, h):
 - Continuous scanning: avoid recomputing all 50+ region keys on every position update
 
 Note: this caching optimization applies to spatial region computations for discovery. Hop proofs still require computing the temporal axis root per §5 on every hop.
+
+### 7.6 Hints (optional)
+
+A bag's `lookup_id` reveals nothing about where it is (§7.2), and a scan finds only what lies within a few heights of the scanner (§7.3). Without more, a bag can only be stumbled upon. A **hint** is the hider's optional, coarse, public statement of where a bag can be found. It turns the bag into something a seeker can look for, and the hider chooses how coarse it is.
+
+**The hinted box (normative):**
+
+A hint names an **aligned box**: one aligned region per axis, each with its own height, on one plane.
+- `Hx`, `Hy`, `Hz`: integers in `[0, 85]`, the hint heights
+- `bx = (x >> Hx) << Hx`, and likewise `by` and `bz`: the aligned bases
+- the box is `[bx, bx + 2^Hx) × [by, by + 2^Hy) × [bz, bz + 2^Hz)` on plane `P`
+
+A height of `85` leaves that axis entirely open (base `0`, the whole axis). Equal heights give a cube; unequal heights give a slab or a column. Heights of `30` on all three axes name exactly one sector (§10).
+
+**The hint tag (normative):**
+
+`["hint", "<coord256_hex>", "<Hx>", "<Hy>", "<Hz>"]`
+
+- `coord256_hex` is the 256-bit coordinate of the box's base `(bx, by, bz, P)`, encoded per §2.2 and §2.3, 32 bytes of lowercase hex. It MUST be the aligned base: on each axis the low `H` bits MUST be zero, and an axis with `H = 85` MUST be `0`.
+- `Hx`, `Hy`, `Hz` MUST be base-10 integers with no sign and no leading zeros (except `"0"`), the formatting rules of §10.
+- A bag MUST carry at most one `hint` tag.
+
+**The claim (normative):**
+
+A hint asserts that the bag's region, the aligned cube of the bag's height `h` (the `h` tag of §8.6) whose key encrypts the content, lies inside the box on plane `P`. Because both are aligned, this holds exactly when each hint height is at least `h` and the region's base agrees with the box's base above each hint height. Accordingly, when the bag carries an `h` tag, each of `Hx`, `Hy`, `Hz` MUST be at least `h`. A hint whose three heights all equal `h` names the region exactly: a destination rather than a search.
+
+**Sector tags (normative):**
+
+For each axis whose hint height is at most `30`, the sector on that axis is determined, and the bag MUST carry that axis's sector tag (`X`, `Y` or `Z`), computed from the box's base per §10. When all three are determined the bag MUST also carry the combined `S` tag. An axis whose hint height is above `30` carries no sector tag. A bag without a `hint` tag MUST NOT carry sector tags: on a bag, sector tags are derived from the hint and carry no independent information.
+
+**Malformed hints (normative):**
+
+A `hint` tag that breaks any rule above (wrong arity, invalid hex, a base that is not aligned, a height outside `[0, 85]`, a non-canonical integer, a height below the bag's `h`) MUST be treated as absent, and sector tags that disagree with the hint MUST be ignored. A malformed hint never invalidates the bag: hints are advisory metadata, and the bag's validity is a matter of §7.2 and §8.6 alone.
+
+**What a hint costs a seeker (non-normative):**
+
+A seeker who trusts a hint sweeps the box at the bag's height: `2^((Hx - h) + (Hy - h) + (Hz - h))` candidate regions, each costing one key derivation at height `h` (§7.2, §7.4) and one lookup by `lookup_id` (or one batched relay query for many). This work does not depend on where the seeker stands. Per §7.1, looking and walking cost the same, and a key can be derived for any coordinate. The **gap** between hint height and bag height is therefore the hider's difficulty knob, set per axis:
+
+| Total gap (sum over axes) | Candidates | Single-core sweep for a bag at height 8 or below |
+|---:|---:|---|
+| 0 | 1 | a destination |
+| 12 | 4,096 | seconds |
+| 18 | 262,144 | minutes |
+| 24 | 16.7 million | hours |
+| 30 or more | a billion or more | days to never |
+
+Key derivation on one desktop core measured about 0.05 ms at heights 0 to 4, 1.3 ms at height 8, 30 ms at height 12 and 816 ms at height 16 (2026-09-01), so the same gap costs more for a bag hidden at a greater height. A sector-only hint (heights of `30`) on a bag hidden at height 5 is a gap of 75: hopeless as a search, useful only as a place to travel to.
+
+**Reading versus reaching (non-normative):**
+
+Deriving the key lets anyone who did the work read the bag from anywhere. Standing inside the region is a different fact, provable only by a movement chain whose head lies inside it (§8). Applications that reward a find should decide which of the two they mean. Whether and how a find is proven publicly is left to applications and extensions (§8.9).
+
+**Truthfulness (non-normative):**
+
+A hint is a claim by the hider, unverifiable until the bag is found. A false hint wastes seekers' work, and nothing in the protocol punishes it. Applications should weight hints by the hider's reputation, as they would any other unverified statement.
+
+**Narrative hints (non-normative):**
+
+The bag's `content` field MAY carry a plaintext hint for humans, a riddle, alongside or instead of a geometric hint (§8.6). The protocol does not interpret it.
+
+**Golden vectors:**
+
+Produced and checked by `hint-reference.py`. Points are 256-bit coordinates per §2.2 (32 bytes of hex); `london` is the §9.8 golden vector.
+
+| Vector | Point (plane) | Bag `h` | Heights | `hint` coordinate | Sector tags | Candidates |
+|---|---|---:|---|---|---|---:|
+| `london_h5_box11` | `london` (0) | 5 | 11, 11, 11 | `c492492492492492492492edf5bee7267451c787d95ba4d7840c76d000000000` | `X` `18014398541305938`, `Y` `18014398549232983`, `Z` `18014398509410999`, `S` `18014398541305938-18014398549232983-18014398509410999` | 2^18 |
+| `london_h5_x_exact` | `london` (0) | 5 | 5, 14, 14 | `c492492492492492492492edf5bee7267451c787d95ba4d7840c749041240000` | same as above | 2^18 |
+| `ideaspace_h8_y_open` | `a4b64924924924924924924924924924924924924924924924924d84b60d9c8f` (1) | 8 | 12, 40, 12 | `a4b64924924924924924924924924924924924924924924924924d8000000001` | `X` `18014398509481984`, `Z` `36028797018963967`, no `Y`, no `S` | 2^40 |
+
+The ideaspace point is `x = 2^84 + 12345`, `y = 3 · 2^80 + 777`, `z = 2^85 - 1 - 4242` on plane 1. The second vector is a two-dimensional hunt: X is exact, so the seeker sweeps a 2^9 by 2^9 slab of height-5 regions. The third shows an open axis: with `Hy = 40` the Y sector is undetermined, so the bag carries `X` and `Z` but neither `Y` nor `S`, and the sweep is 2^40 candidates, a hint that names a place to travel to rather than a search anyone will finish.
 
 ---
 
@@ -1019,7 +1091,11 @@ Required tags:
 - `d` tag: `["d", "<lookup_id_hex>"]` (32-byte lowercase hex string)
 
 Optional tags:
-- `h` tag: `["h", "<height_hint>"]` (string integer)
+- `h` tag: `["h", "<height_hint>"]` (string integer): the height of the region whose key encrypts the content, the discovery radius of §7.3
+- `hint` tag: `["hint", "<coord256_hex>", "<Hx>", "<Hy>", "<Hz>"]`: the hider's coarse statement of where the bag can be found, per §7.6
+- `X`, `Y`, `Z`, `S` tags: on a bag that carries a `hint` tag, required for each axis whose hint height is at most 30, per §7.6 and §10; MUST NOT appear otherwise
+
+Content: MAY carry a plaintext hint for humans, a riddle; the protocol does not interpret it (§7.6).
 
 The encryption algorithm and ciphertext encoding (base64 vs hex) are out of scope for this spec; only lookup and key derivation are specified.
 
@@ -1253,6 +1329,8 @@ Tag formatting rules (normative):
 - `sx`, `sy`, `sz` MUST be encoded as base-10 integers (strings), with no leading `+` and no leading zeros (except `"0"`).
 - `S` MUST be exactly `"<sx>-<sy>-<sz>"`.
 
+**Encrypted content events (kind 33330):** a bag without a hint claims no coordinate and MUST NOT carry sector tags. A bag with a hint (§7.6) claims a box, and MUST carry the sector tag for each axis whose hint height is at most 30, computed from the box's base, plus the `S` tag when all three are determined. A relay query on `#S`, or on a single axis tag, therefore returns the hinted bags in a sector or a slice the same way it returns movement.
+
 ---
 
 ## 11. Visualization Conventions
@@ -1382,3 +1460,5 @@ Implementers should treat that repo as the reference for:
 - Integer→bytes canonicalization for hashing
 - Movement proof computation
 - Canonical GPS→dataspace mapping (`CANONICAL_GPS_TO_DATASPACE_SPEC_VERSION` and golden vectors)
+
+This repository also carries `hint-reference.py`, a stdlib-only executable statement of §7.6 and its sector rule in §10: it checks canonical form, containment, sector tags, seeker work, malformed hints and plane preservation, and locks the golden vectors of §7.6.

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -113,6 +113,14 @@ Each Cantor number represents a **region**, not a point. A number computed at he
 
 Anyone who traverses through the region computes the same Cantor number. They derive the same decryption key. They discover the same content.
 
+### Hints: The Hider Chooses How Bright the Chalk Is
+
+Chalk that nobody knows about is not chalk on a sidewalk; it is chalk in a drawer. The lookup id deliberately reveals nothing, and a scan only reaches a few heights around the scanner, so an unhinted bag in a 2^255 space can only be stumbled upon. That is the right default for an intimate message and the wrong one for anything meant to be found.
+
+A hint (spec §7.6) is the hider's answer, and it is the hider's alone: an aligned box, one height per axis, published on the bag. The gap between the box and the bag's own region is the price of the search, because a seeker sweeps the box by deriving keys at the bag's height, and the work equivalence of §7.1 says that sweep costs the same from anywhere. Nothing about the seeker's position enters the cost of *reading*. Only *reaching*, standing in the region with a movement chain to prove it, still costs distance. Keeping those two apart is the point: the protocol hands the hider a difficulty knob and hands applications a clean fact to reward, without inventing a registry, a referee, or a trusted index.
+
+Per-axis heights fall out of the aligned geometry for free and turn out to matter. An exact X with coarse Y and Z is a two-dimensional hunt. A sector on all three axes is a place to travel to rather than a place to search. Three heights equal to the bag's own height is a destination. One tag covers all of them, and the sector tags of §10 come along whenever a hint fixes a sector, so relays can answer "what is hidden in this sector" without a new query language.
+
 ---
 
 ## 4. What Cyberspace Does NOT Solve

--- a/hint-reference.py
+++ b/hint-reference.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""CYBERSPACE_V2 section 7.6: reference hint construction (stdlib only).
+
+A hint is the hider's optional, coarse statement of where an encrypted content
+event (kind 33330, section 8.6) can be found: an aligned box, one height per
+axis, on one plane. This file is the executable statement of section 7.6 and
+the sector rule it adds to section 10. Running it checks the properties those
+sections claim:
+
+  1. the hint coordinate is the aligned base of the box, so every point in
+     the box yields the same hint (canonical form)
+  2. the bag's own region (height h) lies inside the box exactly when every
+     hint height is at least h and the bases agree above H (containment)
+  3. sector tags appear for exactly the axes whose hint height is 30 or less,
+     and S appears only when all three do (section 10)
+  4. the seeker's work is 2^((Hx-h)+(Hy-h)+(Hz-h)) region-key derivations
+     at height h, and does not depend on where the seeker stands
+  5. malformed hints (bad hex, non-aligned base, a height below h or above
+     85, a non-integer) are treated as absent, never as a reason to reject
+     the bag
+  6. the plane bit survives the round trip, so a hint names one plane
+
+Golden vectors at the bottom lock the construction for other implementations.
+"""
+import json
+
+AXIS_BITS = 85
+AXIS_MAX = (1 << AXIS_BITS) - 1
+SECTOR_SHIFT = 30                       # section 10: a sector is 2^30 Gibsons per axis
+HINT_TAG = "hint"
+
+
+# --- section 2.3, verbatim semantics -------------------------------------------
+
+def xyz_to_coord(x: int, y: int, z: int, plane: int = 0) -> int:
+    coord = plane & 1
+    for i in range(AXIS_BITS):
+        coord |= ((z >> i) & 1) << (1 + i * 3)
+        coord |= ((y >> i) & 1) << (2 + i * 3)
+        coord |= ((x >> i) & 1) << (3 + i * 3)
+    return coord
+
+
+def coord_to_xyz(coord: int) -> tuple:
+    plane = coord & 1
+    x = y = z = 0
+    for i in range(AXIS_BITS):
+        z |= ((coord >> (1 + i * 3)) & 1) << i
+        y |= ((coord >> (2 + i * 3)) & 1) << i
+        x |= ((coord >> (3 + i * 3)) & 1) << i
+    return (x, y, z, plane)
+
+
+def coord_hex(coord: int) -> str:
+    return format(coord, "064x")
+
+
+# --- section 7.6: building a hint -----------------------------------------------
+
+def aligned_base(v: int, height: int) -> int:
+    """The base of the aligned region of side 2^height containing v (sections 4.5, 7.4)."""
+    return (v >> height) << height
+
+
+def hint_tags(x: int, y: int, z: int, plane: int, heights: tuple) -> list:
+    """The tags a hider adds to a bag: the hint itself plus the section 10 sector
+    tags for every axis whose hint height fixes the sector. Any point in the box
+    may be passed; the hint carries the aligned base."""
+    hx, hy, hz = heights
+    bx, by, bz = aligned_base(x, hx), aligned_base(y, hy), aligned_base(z, hz)
+    tags = [[HINT_TAG, coord_hex(xyz_to_coord(bx, by, bz, plane)), str(hx), str(hy), str(hz)]]
+    known = {}
+    for name, base, h in (("X", bx, hx), ("Y", by, hy), ("Z", bz, hz)):
+        if h <= SECTOR_SHIFT:
+            known[name] = str(base >> SECTOR_SHIFT)
+            tags.append([name, known[name]])
+    if len(known) == 3:
+        tags.append(["S", f"{known['X']}-{known['Y']}-{known['Z']}"])
+    return tags
+
+
+def candidates(bag_height: int, heights: tuple) -> int:
+    """Region-key derivations at bag_height needed to sweep the box (section 7.6)."""
+    return 1 << sum(h - bag_height for h in heights)
+
+
+# --- section 7.6: reading a hint ------------------------------------------------
+
+def parse_hint(tags: list, bag_height: int):
+    """The hinted box as (bx, by, bz, plane, (Hx, Hy, Hz)), or None when the bag
+    carries no well-formed hint. A malformed hint is absent, not an error: the
+    bag itself stays valid (section 7.6)."""
+    hint = next((t for t in tags if t and t[0] == HINT_TAG), None)
+    if hint is None or len(hint) != 5:
+        return None
+    try:
+        if len(hint[1]) != 64:
+            return None
+        coord = int(hint[1], 16)
+        heights = tuple(int(h) for h in hint[2:5])
+    except ValueError:
+        return None
+    if any(str(h) != s for h, s in zip(heights, hint[2:5])):
+        return None                      # "07", "+5", " 5": not canonical base-10
+    if any(h < bag_height or h > AXIS_BITS for h in heights):
+        return None
+    if coord >> 256:
+        return None
+    x, y, z, plane = coord_to_xyz(coord)
+    for v, h in zip((x, y, z), heights):
+        if h < AXIS_BITS and v & ((1 << h) - 1):
+            return None                  # not the aligned base
+        if h == AXIS_BITS and v:
+            return None                  # a whole-axis hint has base 0
+    return (x, y, z, plane, heights)
+
+
+def contains(hint, x: int, y: int, z: int, plane: int, bag_height: int) -> bool:
+    """Does the bag's region at bag_height lie inside the hinted box?"""
+    bx, by, bz, hplane, (hx, hy, hz) = hint
+    if plane != hplane:
+        return False
+    return (aligned_base(x, hx) == bx and aligned_base(y, hy) == by
+            and aligned_base(z, hz) == bz and min(hx, hy, hz) >= bag_height)
+
+
+# --- checks ---------------------------------------------------------------------
+
+LONDON = "c492492492492492492492edf5bee7267451c787d95ba4d7840c76d1e33c9940"   # section 9.8
+
+
+def check() -> None:
+    lx, ly, lz, lplane = coord_to_xyz(int(LONDON, 16))
+    assert lplane == 0 and coord_hex(xyz_to_coord(lx, ly, lz, 0)) == LONDON
+
+    # 1. canonical form: any point in the box gives the same hint
+    h, heights = 5, (11, 11, 11)
+    a = hint_tags(lx, ly, lz, 0, heights)
+    b = hint_tags(lx ^ 0x3FF, ly | 0x7FF, lz & ~0x7FF, 0, heights)
+    assert a == b
+
+    # 2. containment
+    hint = parse_hint(a, h)
+    assert hint is not None
+    assert contains(hint, lx, ly, lz, 0, h)
+    assert not contains(hint, lx + (1 << 11), ly, lz, 0, h)      # next box along X
+    assert not contains(hint, lx, ly, lz, 1, h)                  # other plane
+    assert not contains(hint, lx, ly, lz, 0, 12)                 # region larger than the box
+
+    # 3. sector tags: exactly the axes with H <= 30, S only when all three
+    names = [t[0] for t in a]
+    assert names == [HINT_TAG, "X", "Y", "Z", "S"]
+    partial = hint_tags(lx, ly, lz, 0, (12, 40, 12))
+    assert [t[0] for t in partial] == [HINT_TAG, "X", "Z"]
+    whole = hint_tags(lx, ly, lz, 0, (85, 85, 85))
+    assert [t[0] for t in whole] == [HINT_TAG]
+    assert whole[0][1] == coord_hex(0)
+
+    # 4. the seeker's work
+    assert candidates(5, (11, 11, 11)) == 1 << 18
+    assert candidates(5, (5, 14, 14)) == 1 << 18                 # a 2D hunt: X exact
+    assert candidates(5, (5, 5, 5)) == 1                         # exact: a destination
+    assert candidates(8, (12, 40, 12)) == 1 << 40                # a hopeless hint
+
+    # 5. malformed hints are absent, not fatal
+    assert parse_hint([[HINT_TAG, a[0][1], "4", "11", "11"]], 5) is None      # H below h
+    assert parse_hint([[HINT_TAG, a[0][1], "11", "11", "86"]], 5) is None     # above 85
+    assert parse_hint([[HINT_TAG, a[0][1], "11", "11"]], 5) is None           # missing height
+    assert parse_hint([[HINT_TAG, a[0][1], "11", "11", "011"]], 5) is None    # not canonical
+    assert parse_hint([[HINT_TAG, "zz" * 32, "11", "11", "11"]], 5) is None   # bad hex
+    assert parse_hint([[HINT_TAG, LONDON, "11", "11", "11"]], 5) is None      # not aligned
+    assert parse_hint([["d", "00" * 32]], 5) is None                          # no hint at all
+    assert parse_hint(a, 11) is not None and parse_hint(a, 12) is None
+
+    # 6. the plane survives
+    idea = hint_tags(lx, ly, lz, 1, heights)
+    assert coord_to_xyz(int(idea[0][1], 16))[3] == 1
+    assert idea[1:] == a[1:]                                     # same sectors, other plane
+
+
+def vectors() -> dict:
+    lx, ly, lz, _ = coord_to_xyz(int(LONDON, 16))
+    ix, iy, iz = (1 << 84) + 12345, 3 * (1 << 80) + 777, AXIS_MAX - 4242
+    return {
+        "london_h5_box11": {"point": LONDON, "plane": 0, "bag_height": 5, "heights": [11, 11, 11],
+                            "tags": hint_tags(lx, ly, lz, 0, (11, 11, 11)), "candidates_log2": 18},
+        "london_h5_x_exact": {"point": LONDON, "plane": 0, "bag_height": 5, "heights": [5, 14, 14],
+                              "tags": hint_tags(lx, ly, lz, 0, (5, 14, 14)), "candidates_log2": 18},
+        "ideaspace_h8_y_open": {"point": coord_hex(xyz_to_coord(ix, iy, iz, 1)), "plane": 1, "bag_height": 8,
+                                "heights": [12, 40, 12], "tags": hint_tags(ix, iy, iz, 1, (12, 40, 12)),
+                                "candidates_log2": 40},
+    }
+
+
+GOLDEN = {
+    "london_h5_box11": {
+        "point": "c492492492492492492492edf5bee7267451c787d95ba4d7840c76d1e33c9940",
+        "plane": 0,
+        "bag_height": 5,
+        "heights": [
+            11,
+            11,
+            11
+        ],
+        "tags": [
+            [
+                "hint",
+                "c492492492492492492492edf5bee7267451c787d95ba4d7840c76d000000000",
+                "11",
+                "11",
+                "11"
+            ],
+            [
+                "X",
+                "18014398541305938"
+            ],
+            [
+                "Y",
+                "18014398549232983"
+            ],
+            [
+                "Z",
+                "18014398509410999"
+            ],
+            [
+                "S",
+                "18014398541305938-18014398549232983-18014398509410999"
+            ]
+        ],
+        "candidates_log2": 18
+    },
+    "london_h5_x_exact": {
+        "point": "c492492492492492492492edf5bee7267451c787d95ba4d7840c76d1e33c9940",
+        "plane": 0,
+        "bag_height": 5,
+        "heights": [
+            5,
+            14,
+            14
+        ],
+        "tags": [
+            [
+                "hint",
+                "c492492492492492492492edf5bee7267451c787d95ba4d7840c749041240000",
+                "5",
+                "14",
+                "14"
+            ],
+            [
+                "X",
+                "18014398541305938"
+            ],
+            [
+                "Y",
+                "18014398549232983"
+            ],
+            [
+                "Z",
+                "18014398509410999"
+            ],
+            [
+                "S",
+                "18014398541305938-18014398549232983-18014398509410999"
+            ]
+        ],
+        "candidates_log2": 18
+    },
+    "ideaspace_h8_y_open": {
+        "point": "a4b64924924924924924924924924924924924924924924924924d84b60d9c8f",
+        "plane": 1,
+        "bag_height": 8,
+        "heights": [
+            12,
+            40,
+            12
+        ],
+        "tags": [
+            [
+                "hint",
+                "a4b64924924924924924924924924924924924924924924924924d8000000001",
+                "12",
+                "40",
+                "12"
+            ],
+            [
+                "X",
+                "18014398509481984"
+            ],
+            [
+                "Z",
+                "36028797018963967"
+            ]
+        ],
+        "candidates_log2": 40
+    }
+}
+
+
+if __name__ == "__main__":
+    check()
+    out = vectors()
+    if GOLDEN is not None:
+        assert out == GOLDEN, "golden vectors drifted"
+    print(json.dumps(out, indent=1))
+    print("hint-reference: all checks passed")


### PR DESCRIPTION
## What

A new **§7.6 Hints (optional)**: a kind 33330 bag may carry the hider's coarse, public statement of where it can be found.

- `["hint", "<coord256_hex>", "<Hx>", "<Hy>", "<Hz>"]`: the 256-bit coordinate of the box's **aligned base** (§2 encoding, plane bit included) plus one hint height per axis. The box is the aligned region of side 2^H per axis, on that plane. Heights of 85 leave an axis open; heights equal to the bag's own height name the region exactly.
- Each hint height MUST be at least the bag's `h`. The base MUST be aligned (canonical form). A bag carries at most one hint.
- **Sector tags (§10)** become mandatory on a hinted bag for every axis whose hint height is 30 or less, with `S` when all three are known, so relays answer "what is hidden in this sector" with existing filters. A bag without a hint MUST NOT carry them.
- **Malformed hints are treated as absent** and never invalidate the bag; hints are advisory metadata.
- `content` MAY carry a plaintext riddle.
- §8.6 lists the optional tags, §7.3 points at §7.6, §10 states the kind 33330 rule, §14 lists the reference script, and RATIONALE §3 gains "Hints: The Hider Chooses How Bright the Chalk Is".

## Why

The relay holds 29 bags from 19 hiders and nothing anywhere says where any of them is. Cyberspace is unlit rather than empty. §7.1 already establishes that looking and walking cost the same and that a key can be derived for any coordinate, so **seeking is distance-independent**: a hinted bag anywhere is huntable by anyone by computation, and only *reaching* it (a chain head inside the region) still costs distance. That makes the **gap** between hint height and bag height the hider's difficulty knob, and per-axis heights give sector hints, exact-X two-dimensional hunts, and destinations with one tag. This is the protocol half of the Loot work in the ONOSENDAI client (arkin0x/ONOSENDAI#44 is the first slice).

## Verification

`python3 hint-reference.py` passes six property checks (canonical form, containment, sector tags, seeker work, malformed hints, plane preservation) and locks three golden vectors, which are also tabulated in §7.6:

| Vector | Heights | Candidates |
|---|---|---:|
| `london_h5_box11` (dataspace, §9.8 london point) | 11, 11, 11 | 2^18 |
| `london_h5_x_exact` (a 2D hunt) | 5, 14, 14 | 2^18 |
| `ideaspace_h8_y_open` (open Y: no `Y`, no `S`) | 12, 40, 12 | 2^40 |

The difficulty ladder in §7.6 is non-normative and comes from measured key-derivation cost (0.05 ms at h0 to h4, 1.3 ms at h8, 30 ms at h12, 816 ms at h16, one core, 2026-09-01).

## Versioning

No change to `CANONICAL_GPS_TO_DATASPACE_SPEC_VERSION`: §9.5 governs the GPS mapping only, and these tags are additive and optional. "Last updated" bumped to September 1, 2026.

## Interplay

PR #20 (sidestep tolls) edits §6 and adds a reference-script list to §14; this PR adds one sentence to §14 in the same place, so whichever merges second may need a one-line merge. No overlap otherwise.

Follow-ups (private launch map): client deploy-bar hint chooser and Loot v1, and `cyberspace encrypt` emitting the same tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfomSfTsFyuBjgqFoSTfxc
